### PR TITLE
Containerize frontend

### DIFF
--- a/marinerescue-frontend/.dockerignore
+++ b/marinerescue-frontend/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+build
+.dockerignore
+Dockerfile
+Dockerfile.prod

--- a/marinerescue-frontend/Dockerfile
+++ b/marinerescue-frontend/Dockerfile
@@ -1,0 +1,20 @@
+# https://scotch.io/tutorials/react-docker-with-security-in-10-minutes
+FROM node:14.1-alpine AS builder
+
+WORKDIR /opt/web
+COPY package.json package-lock.json ./
+RUN npm install
+
+ENV PATH="./node_modules/.bin:$PATH"
+
+COPY . ./
+RUN npm run build
+
+FROM nginx:1.17-alpine
+RUN apk --no-cache add curl
+RUN curl -L https://github.com/a8m/envsubst/releases/download/v1.1.0/envsubst-`uname -s`-`uname -m` -o envsubst && \
+    chmod +x envsubst && \
+    mv envsubst /usr/local/bin
+COPY ./nginx.config /etc/nginx/nginx.template
+CMD ["/bin/sh", "-c", "envsubst < /etc/nginx/nginx.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"]
+COPY --from=builder /opt/web/build /usr/share/nginx/html

--- a/marinerescue-frontend/nginx.config
+++ b/marinerescue-frontend/nginx.config
@@ -1,0 +1,16 @@
+server {
+    listen       ${PORT:-80};
+    listen 443;
+    ssl on;
+    server_name  marinerescue.app;
+    ssl_certificate /etc/ssl/fullchain.pem;
+    ssl_certificate_key /etc/ssl/privkey.pem;
+    server_tokens off;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $$uri /index.html;
+    }
+}


### PR DESCRIPTION
This PR/commit adds the code to Dockerize `marinerescue-frontend` as an NGINX webhost that supports SSL and React Router. The Docker package name is `andreybutenko/marinerescue-frontend`

Use this command to run the container on any host with LetsEncrypt configured:

```
docker run -p 80:80 -p 443:80 --name mr-fe \
  -v /etc/letsencrypt/live/marinerescue.app/fullchain.pem:/etc/ssl/fullchain.pem \
  -v /etc/letsencrypt/live/marinerescue.app/privkey.pem:/etc/ssl/privkey.pem \
  -d andreybutenko/marinerescue-frontend
```

The build command is standard:

```
docker build -t andreybutenko/marinerescue-frontend .
```