### PR TITLE
Combine stories, story transitions

### DIFF
--- a/docs/StorytellerDataFormat.md
+++ b/docs/StorytellerDataFormat.md
@@ -44,7 +44,7 @@ A scene is an object that looks like this:
 * `background`: Background to be displayed if this scene is a comic. All backgrounds are in the `/marinerescue-frontend/public/sprites/` directory with `bg-` prefix.
 * `minigame`: Name of minigame React Component if this scene is a minigame.
 * `nextScene`: Either a string or an object that determines the scene to change to after this scene is complete.
-  * `string`: Scene to change to after this scene is complete.
+  * `string`: Scene to change to after this scene is complete. If `nextScene` begins with `"GOTO"`, it indicates that the user should be navigated to another page after completing this scene (i.e. `"nextScene": "GOTO /play?next=squawky"`).
   * `object`: A map of labels to destination scenes. Depending on the label chosen by the player in a decision, the scene will change to the given destination scene.
 * `baseFrame`: A base frame that is prepended to every frame in the scene.
 * `frames`: All the frames in the scene.

--- a/marinerescue-frontend/src/App.js
+++ b/marinerescue-frontend/src/App.js
@@ -16,6 +16,7 @@ import ParentsPage from './pages/ParentsPage';
 import GameLandingPage from './pages/GameLandingPage';
 import CapstonePage from './pages/CapstonePage';
 import BadgesPage from './pages/BadgesPage';
+import StorytellerPage from "./pages/StorytellerPage";
 
 function App() {
     return (
@@ -38,6 +39,15 @@ function App() {
                 </Route>
                 <Route path="/storyteller-test">
                     <Storyteller />
+                </Route>
+                <Route path="/play/strawberry">
+                    <StorytellerPage startSceneLabel="strawberry" />
+                </Route>
+                <Route path="/play/humphrey">
+                    <StorytellerPage startSceneLabel="humphrey" />
+                </Route>
+                <Route path="/play/jade">
+                    <StorytellerPage startSceneLabel="jade" />
                 </Route>
                 <Route path="/play">
                     <GameLandingPage />

--- a/marinerescue-frontend/src/components/ComicView.js
+++ b/marinerescue-frontend/src/components/ComicView.js
@@ -5,7 +5,7 @@ import {
     JOURNAL_ENTRY_VIEW,
 } from './Journal';
 
-import journalData from '../journalData';
+import JOURNAL_DATA from '../data/JournalData';
 
 const ELEMENT_TYPE_SPRITE = 'sprite';
 const ELEMENT_TYPE_JOURNAL = 'journal';
@@ -78,7 +78,7 @@ class ComicView extends React.Component {
                     top: element.y,
                     textAlign: 'left',
                 }}
-                data={journalData}
+                data={JOURNAL_DATA}
                 view={JOURNAL_ENTRY_VIEW}
                 page={element.title} 
                 onNavigate={() => {}}

--- a/marinerescue-frontend/src/components/Storyteller.js
+++ b/marinerescue-frontend/src/components/Storyteller.js
@@ -5,7 +5,7 @@ import React from 'react';
 import Cookies from 'universal-cookie';
 import ComicView from './ComicView';
 import minigames from './minigames';
-import storytellerData from '../storytellerData';
+import STORYTELLER_DATA from '../data/StorytellerData';
 import './Storyteller.scss';
 
 const STORYTELLER_COOKIE = 'storytellerCookie';
@@ -77,20 +77,20 @@ class Storyteller extends React.Component {
             sceneHistory: [...this.state.sceneHistory, this.state.currentScene],
         });
 
-        if (this.getCurrentScene().type !== 'minigame' && oldSceneFrame + 1 < storytellerData[oldSceneName].frames.length) {
+        if (this.getCurrentScene().type !== 'minigame' && oldSceneFrame + 1 < STORYTELLER_DATA[oldSceneName].frames.length) {
             this.setState({
                 currentScene: `${oldSceneName}/${oldSceneFrame + 1}`,
             });
         }
         else {
-            newSceneName = storytellerData[oldSceneName].nextScene;
+            newSceneName = STORYTELLER_DATA[oldSceneName].nextScene;
             this.setState({
                 currentScene: `${newSceneName}/0`,
             });
         }
 
         // Clear history before and after minigames to avoid weird UX
-        if (storytellerData[oldSceneName].type === 'minigame' || (!!newSceneName && storytellerData[newSceneName].type === 'minigame')) {
+        if (STORYTELLER_DATA[oldSceneName].type === 'minigame' || (!!newSceneName && STORYTELLER_DATA[newSceneName].type === 'minigame')) {
             this.setState({
                 sceneHistory: [],
             });
@@ -100,7 +100,7 @@ class Storyteller extends React.Component {
     // Get current game scene
     getCurrentScene() {
         const [sceneName] = this.getParsedSceneAttrs();
-        return storytellerData[sceneName];
+        return STORYTELLER_DATA[sceneName];
     }
 
     // Get data about the current game state required for `ComicView`

--- a/marinerescue-frontend/src/components/Storyteller.js
+++ b/marinerescue-frontend/src/components/Storyteller.js
@@ -19,14 +19,14 @@ let cookies = null;
 class Storyteller extends React.Component {
     constructor(props) {
         super(props);
-        this.state = this.getDefaultState();
+        this.state = this.getDefaultState(props.startScene);
     }
 
     // Get default game state
-    getDefaultState() {
+    getDefaultState(startScene) {
         return {
             stateFormatVersion: 0,
-            currentScene: 'testScene/0',
+            currentScene: `${startScene || 'testScene'}/0`,
             sceneHistory: [],
             complete: [],
         };

--- a/marinerescue-frontend/src/components/Storyteller.js
+++ b/marinerescue-frontend/src/components/Storyteller.js
@@ -2,6 +2,7 @@
 // See documentation in /docs/StorytellerDataFormat.md
 
 import React from 'react';
+import { withRouter } from "react-router-dom";
 import Cookies from 'universal-cookie';
 import ComicView from './ComicView';
 import minigames from './minigames';
@@ -78,15 +79,28 @@ class Storyteller extends React.Component {
         });
 
         if (this.getCurrentScene().type !== 'minigame' && oldSceneFrame + 1 < STORYTELLER_DATA[oldSceneName].frames.length) {
+            // Transition to new frame in same scene
             this.setState({
                 currentScene: `${oldSceneName}/${oldSceneFrame + 1}`,
             });
         }
         else {
             newSceneName = STORYTELLER_DATA[oldSceneName].nextScene;
-            this.setState({
-                currentScene: `${newSceneName}/0`,
-            });
+            console.log(newSceneName)
+            if (newSceneName.substring(0, 4) === 'GOTO') {
+                // Transition to another webpage
+                const destination =  newSceneName.split(' ')[1];
+                this.props.history.push(destination);
+                return;
+            }
+            else {
+                // Transition to a new scene
+                // Next line of code makes this case insensitive due to a bug in the editor
+                newSceneName = Object.keys(STORYTELLER_DATA).find(key => key.toLowerCase() === newSceneName.toLowerCase())
+                this.setState({
+                    currentScene: `${newSceneName}/0`,
+                });
+            }
         }
 
         // Clear history before and after minigames to avoid weird UX
@@ -190,4 +204,4 @@ class Storyteller extends React.Component {
     }
 }
 
-export default Storyteller;
+export default withRouter(Storyteller);

--- a/marinerescue-frontend/src/data/JournalData.js
+++ b/marinerescue-frontend/src/data/JournalData.js
@@ -1,4 +1,4 @@
-const journalData = [
+const JOURNAL_DATA = [
     {
         title: 'Squawky',
         category: 'Animals',
@@ -85,4 +85,4 @@ const journalData = [
     }
 ];
 
-export default journalData;
+export default JOURNAL_DATA;

--- a/marinerescue-frontend/src/data/Modules.js
+++ b/marinerescue-frontend/src/data/Modules.js
@@ -1,36 +1,42 @@
 const MODULES = [
     {
         title: 'Meet Strawberry',
+        tag: 'strawberry',
         subtitle: 'Learn about marine debris impacts on Harbor Seals!',
         icon: '/images/landing-page-modules/landing-page-strawberry.png',
         target: '/play/strawberry',
     },
     {
         title: 'Meet Squawky',
+        tag: 'squawky',
         subtitle: 'Learn about marine debris impacts on Albatrosses!',
         icon: '/images/landing-page-modules/landing-page-squawky.png',
         target: '/play/squawky',
     },
     {
         title: 'Meet Humphrey',
+        tag: 'humphrey',
         subtitle: 'Learn about marine debris impacts on Whales!',
         icon: '/images/landing-page-modules/landing-page-humphrey.png',
         target: '/play/humphrey',
     },
     {
         title: 'Meet Jade',
+        tag: 'jade',
         subtitle: 'Learn about marine debris impacts on Sea Turtles!',
         icon: '/images/landing-page-modules/landing-page-jade.png',
         target: '/play/jade',
     },
     {
         title: 'Debris Classification',
+        tag: 'debris',
         subtitle: 'Practice contributing to citizen science by classifying images of marine debris!',
         icon: null,
         target: '/classify',
     },
     {
         title: 'Go to the Beach!',
+        tag: 'beach',
         subtitle: 'Learn to be safe when cleaning up the beach!',
         icon: null,
         target: '/play/safety',

--- a/marinerescue-frontend/src/data/StorytellerData.js
+++ b/marinerescue-frontend/src/data/StorytellerData.js
@@ -1,4 +1,4 @@
-const storytellerData = {
+const STORYTELLER_DATA = {
     testScene: {
         type: 'comic',
         background: 'test-1',
@@ -115,4 +115,4 @@ const storytellerData = {
     },
 };
 
-export default storytellerData;
+export default STORYTELLER_DATA;

--- a/marinerescue-frontend/src/data/StorytellerData.js
+++ b/marinerescue-frontend/src/data/StorytellerData.js
@@ -1,118 +1,13 @@
+import DEFAULT_DATA from './stories/DefaultData';
+import MEET_STRAWBERRY from './stories/MeetStrawberry';
+import MEET_HUMPHREY from './stories/MeetHumphrey';
+import MEET_JADE from './stories/MeetJade';
+
 const STORYTELLER_DATA = {
-    testScene: {
-        type: 'comic',
-        background: 'test-1',
-        nextScene: 'testScene2',
-        baseFrame: [
-            {
-                type: 'sprite',
-                image: 'strawberry',
-                x: 5,
-                y: 5,
-                size: 8,
-            },
-        ],
-        frames: [
-            [
-                {
-                    id: 1,
-                    type: 'sprite',
-                    image: 'strawberry',
-                    x: 40,
-                    y: 40,
-                    size: 20,
-                },
-                {
-                    type: 'sprite',
-                    image: 'strawberry',
-                    x: 80,
-                    y: 80,
-                    size: 8.3,
-                    flipX: true,
-                },
-                {
-                    type: 'journal',
-                    title: 'Humphrey',
-                    x: 25,
-                    y: 10,
-                },
-            ],
-            [
-                {
-                    id: 1,
-                    type: 'sprite',
-                    image: 'strawberry',
-                    x: 20,
-                    y: 20,
-                    size: 40,
-                },
-                {
-                    type: 'sprite',
-                    image: 'strawberry',
-                    x: 80,
-                    y: 80,
-                    size: 8.3,
-                    flipX: true,
-                },
-            ],
-        ]
-    },
-    testScene2: {
-        type: 'comic',
-        background: 'test-2',
-        nextScene: 'testMinigame',
-        dialogue: [
-            {
-                type: 'left',
-                speaker: 'Strawberry',
-                message: 'I’m showing my friend Ellie around and introducing them to all the animals! Ellie is the newest member of the Marine Rescue team!'
-            },
-            null,
-        ],
-        frames: [
-            [
-                {
-                    id: 1,
-                    type: 'sprite',
-                    image: 'strawberry',
-                    x: 40,
-                    y: 40,
-                    size: 20,
-                },
-                {
-                    type: 'sprite',
-                    image: 'strawberry',
-                    x: 80,
-                    y: 80,
-                    size: 8.3,
-                    flipX: true,
-                },
-            ],
-            [
-                {
-                    id: 1,
-                    type: 'sprite',
-                    image: 'strawberry',
-                    x: 20,
-                    y: 20,
-                    size: 20,
-                },
-                {
-                    type: 'sprite',
-                    image: 'strawberry',
-                    x: 30,
-                    y: 80,
-                    size: 8.3,
-                    flipX: true,
-                },
-            ],
-        ]
-    },
-    testMinigame: {
-        type: 'minigame',
-        nextScene: 'testScene',
-        minigame: 'DemoMinigame',
-    },
+  ...DEFAULT_DATA,
+  ...MEET_STRAWBERRY,
+  ...MEET_HUMPHREY,
+  ...MEET_JADE,
 };
 
 export default STORYTELLER_DATA;

--- a/marinerescue-frontend/src/data/stories/DefaultData.js
+++ b/marinerescue-frontend/src/data/stories/DefaultData.js
@@ -1,0 +1,118 @@
+const DEFAULT_DATA = {
+  testScene: {
+    type: 'comic',
+    background: 'test-1',
+    nextScene: 'testScene2',
+    baseFrame: [
+      {
+        type: 'sprite',
+        image: 'strawberry',
+        x: 5,
+        y: 5,
+        size: 8,
+      },
+    ],
+    frames: [
+      [
+        {
+          id: 1,
+          type: 'sprite',
+          image: 'strawberry',
+          x: 40,
+          y: 40,
+          size: 20,
+        },
+        {
+          type: 'sprite',
+          image: 'strawberry',
+          x: 80,
+          y: 80,
+          size: 8.3,
+          flipX: true,
+        },
+        {
+          type: 'journal',
+          title: 'Humphrey',
+          x: 25,
+          y: 10,
+        },
+      ],
+      [
+        {
+          id: 1,
+          type: 'sprite',
+          image: 'strawberry',
+          x: 20,
+          y: 20,
+          size: 40,
+        },
+        {
+          type: 'sprite',
+          image: 'strawberry',
+          x: 80,
+          y: 80,
+          size: 8.3,
+          flipX: true,
+        },
+      ],
+    ]
+  },
+  testScene2: {
+    type: 'comic',
+    background: 'test-2',
+    nextScene: 'testMinigame',
+    dialogue: [
+      {
+        type: 'left',
+        speaker: 'Strawberry',
+        message: 'I’m showing my friend Ellie around and introducing them to all the animals! Ellie is the newest member of the Marine Rescue team!'
+      },
+      null,
+    ],
+    frames: [
+      [
+        {
+          id: 1,
+          type: 'sprite',
+          image: 'strawberry',
+          x: 40,
+          y: 40,
+          size: 20,
+        },
+        {
+          type: 'sprite',
+          image: 'strawberry',
+          x: 80,
+          y: 80,
+          size: 8.3,
+          flipX: true,
+        },
+      ],
+      [
+        {
+          id: 1,
+          type: 'sprite',
+          image: 'strawberry',
+          x: 20,
+          y: 20,
+          size: 20,
+        },
+        {
+          type: 'sprite',
+          image: 'strawberry',
+          x: 30,
+          y: 80,
+          size: 8.3,
+          flipX: true,
+        },
+      ],
+    ]
+  },
+  testMinigame: {
+    type: 'minigame',
+    nextScene: 'testScene',
+    minigame: 'DemoMinigame',
+  },
+};
+
+export default DEFAULT_DATA;

--- a/marinerescue-frontend/src/data/stories/MeetHumphrey.js
+++ b/marinerescue-frontend/src/data/stories/MeetHumphrey.js
@@ -1,0 +1,491 @@
+const MEET_HUMPHREY = {
+  "MeetHumphrey": {
+    "type": "comic",
+    "background": "beach-big",
+    "nextScene": "meethumphrey-towater",
+    "baseFrame": [
+      {
+        "type": "sprite",
+        "image": "strawberry",
+        "x": 9.3,
+        "y": 35.300000000000004,
+        "size": "40",
+        "flipX": false
+      },
+      {
+        "type": "sprite",
+        "image": "humphrey",
+        "x": 83,
+        "y": 24.9,
+        "size": "010",
+        "flipX": false
+      },
+      {
+        "type": "sprite",
+        "image": "net",
+        "x": 91.00000000000001,
+        "y": 26.1,
+        "size": "02",
+        "flipX": false
+      }
+    ],
+    "frames": [
+      [],
+      [],
+      []
+    ],
+    "dialogue": [
+      {
+        "speaker": "Strawberry",
+        "message": "Wow, do you see that animal way out in the water? That’s Humphrey the Whale!",
+        "type": "left"
+      },
+      {
+        "speaker": "Strawberry",
+        "message": "Whales like Humphrey are huge and live far away from shore. He loves being complimented.\n",
+        "type": "left"
+      },
+      {
+        "speaker": "Strawberry",
+        "message": "We should go meet Humphrey before he dives down deep into the water. Let’s go!",
+        "type": "left"
+      }
+    ]
+  },
+  "MeetHumphrey-towater": {
+    "type": "comic",
+    "background": "beach-small",
+    "nextScene": "meethumphrey-inwater",
+    "baseFrame": [
+      {
+        "type": "sprite",
+        "image": "strawberry",
+        "x": 12.899999999999999,
+        "y": 37.1,
+        "size": "40",
+        "flipX": false
+      },
+      {
+        "type": "sprite",
+        "image": "humphrey",
+        "x": "83",
+        "y": "24.5",
+        "size": "010",
+        "flipX": false
+      },
+      {
+        "type": "sprite",
+        "image": "net",
+        "x": "091.00000000000001",
+        "y": "026.1",
+        "size": "03",
+        "flipX": false
+      }
+    ],
+    "frames": []
+  },
+  "MeetHumphrey-inwater": {
+    "type": "comic",
+    "background": "sea-mountains-left",
+    "nextScene": "netcuttingminigame",
+    "baseFrame": [
+      {
+        "type": "sprite",
+        "image": "strawberry",
+        "x": 4.600000000000001,
+        "y": 46.1,
+        "size": "25",
+        "flipX": false
+      }
+    ],
+    "frames": [
+      [
+        {
+          "type": "sprite",
+          "image": "humphrey",
+          "x": "032",
+          "y": "031.2",
+          "size": "60.4",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "net",
+          "x": "79.5",
+          "y": "037.3",
+          "size": "20",
+          "flipX": false
+        }
+      ],
+      [
+        {
+          "type": "sprite",
+          "image": "humphrey-surprised",
+          "x": "032",
+          "y": "31.2",
+          "size": "060.4",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "net",
+          "x": 79.4,
+          "y": 39.3,
+          "size": "020",
+          "flipX": false
+        }
+      ],
+      [
+        {
+          "type": "sprite",
+          "image": "humphrey",
+          "x": "032",
+          "y": "031.2",
+          "size": "60.4",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "net",
+          "x": "79.5",
+          "y": "037.3",
+          "size": "20",
+          "flipX": false
+        }
+      ],
+      [
+        {
+          "type": "sprite",
+          "image": "humphrey",
+          "x": "032",
+          "y": "031.2",
+          "size": "60.4",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "net",
+          "x": "79.5",
+          "y": "037.3",
+          "size": "20",
+          "flipX": false
+        }
+      ]
+    ],
+    "dialogue": [
+      {
+        "speaker": "Strawberry",
+        "message": "Oh no, Humphrey! What is that?",
+        "type": "left"
+      },
+      {
+        "speaker": "Humphrey",
+        "message": "Huh? Oh, I didn’t even notice! I was about to dive, but it looks like I’m caught in a fishing net.",
+        "type": "right"
+      },
+      {
+        "speaker": "Strawberry",
+        "message": "I’m glad we got to you just in time! If you tried to dive, the fishing might have prevented you from swimming deep enough to catch your prey.",
+        "type": "left"
+      },
+      {
+        "speaker": "Strawberry",
+        "message": "Let’s cut this net off of you!",
+        "type": "left"
+      }
+    ]
+  },
+  "NetCuttingMinigame": {
+    "type": "minigame",
+    "background": "test-1",
+    "nextScene": "meethumphrey-afterminigame",
+    "baseFrame": [],
+    "frames": [],
+    "minigame": "DemoMinigame"
+  },
+  "MeetHumphrey-afterminigame": {
+    "type": "comic",
+    "background": "sea-mountains",
+    "nextScene": {
+      "Hello Humphrey!": "meethumphrey-decision-hi",
+      "You're so BIG!": "meethumphrey-decision-flattery"
+    },
+    "baseFrame": [
+      {
+        "type": "sprite",
+        "image": "strawberry",
+        "x": "04.600000000000001",
+        "y": "046.1",
+        "size": "025",
+        "flipX": false
+      }
+    ],
+    "frames": [
+      [
+        {
+          "type": "sprite",
+          "image": "humphrey",
+          "x": "032",
+          "y": "31.2",
+          "size": "60.4",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "net",
+          "x": 80.5,
+          "y": 56.699999999999996,
+          "size": "20.2",
+          "flipX": false
+        }
+      ],
+      [
+        {
+          "type": "sprite",
+          "image": "net",
+          "x": 80.5,
+          "y": 56.699999999999996,
+          "size": "20.2",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "humphrey-sad",
+          "x": "032",
+          "y": "31.2",
+          "size": "60.4",
+          "flipX": false
+        }
+      ],
+      [
+        {
+          "type": "sprite",
+          "image": "net",
+          "x": 80.5,
+          "y": 56.699999999999996,
+          "size": "20.2",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "humphrey",
+          "x": "032",
+          "y": "31.2",
+          "size": "60.4",
+          "flipX": false
+        }
+      ],
+      [
+        {
+          "type": "sprite",
+          "image": "net",
+          "x": 80.5,
+          "y": 56.699999999999996,
+          "size": "20.2",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "humphrey",
+          "x": "032",
+          "y": "31.2",
+          "size": "60.4",
+          "flipX": false
+        }
+      ]
+    ],
+    "dialogue": [
+      {
+        "speaker": "Humphrey",
+        "message": "Thank you, both, I’m glad you stopped me just in time!",
+        "type": "right"
+      },
+      {
+        "speaker": "Humphrey",
+        "message": "Many marine animals get injured by getting stuck in loopy debris like fishing nets and ropes.",
+        "type": "right"
+      },
+      {
+        "speaker": "Strawberry",
+        "message": "I’m glad we could help out. By the way, this is our newest member of the Marine Rescue Team!",
+        "type": "left"
+      },
+      null
+    ]
+  },
+  "MeetHumphrey-decision-hi": {
+    "type": "comic",
+    "background": "sea-mountains",
+    "nextScene": "meethumphrey-afterdecision",
+    "baseFrame": [
+      {
+        "type": "sprite",
+        "image": "strawberry",
+        "x": "004.600000000000001",
+        "y": "046.1",
+        "size": "25",
+        "flipX": false
+      },
+      {
+        "type": "sprite",
+        "image": "humphrey",
+        "x": "032",
+        "y": "31.2",
+        "size": "60.4",
+        "flipX": false
+      },
+      {
+        "type": "sprite",
+        "image": "net",
+        "x": "080.5",
+        "y": "056.699999999999996",
+        "size": "020.2",
+        "flipX": false
+      }
+    ],
+    "frames": [
+      []
+    ],
+    "dialogue": [
+      {
+        "speaker": "Humphrey",
+        "message": "Hi there, new friend!",
+        "type": "right"
+      }
+    ]
+  },
+  "MeetHumphrey-decision-flattery": {
+    "type": "comic",
+    "background": "sea-mountains",
+    "nextScene": "meethumphrey-afterdecision",
+    "baseFrame": [
+      {
+        "type": "sprite",
+        "image": "strawberry",
+        "x": "004.600000000000001",
+        "y": "046.1",
+        "size": "25",
+        "flipX": false
+      },
+      {
+        "type": "sprite",
+        "image": "humphrey-blush",
+        "x": "032",
+        "y": "31.2",
+        "size": "60.4",
+        "flipX": false
+      },
+      {
+        "type": "sprite",
+        "image": "net",
+        "x": "080.5",
+        "y": "056.699999999999996",
+        "size": "20.2",
+        "flipX": false
+      }
+    ],
+    "frames": [
+      []
+    ],
+    "dialogue": [
+      {
+        "speaker": "Humphrey",
+        "message": "Haha! I like your friend a lot, Strawberry!",
+        "type": "right"
+      }
+    ]
+  },
+  "MeetHumphrey-afterdecision": {
+    "type": "comic",
+    "background": "sea-mountains",
+    "nextScene": "testScene2",
+    "baseFrame": [],
+    "frames": [
+      [
+        {
+          "type": "sprite",
+          "image": "humphrey",
+          "x": "032",
+          "y": "31.2",
+          "size": "60.4",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "net",
+          "x": "080.5",
+          "y": "056.699999999999996",
+          "size": "20.2",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "strawberry",
+          "x": "004.600000000000001",
+          "y": "46.1",
+          "size": "25",
+          "flipX": false
+        }
+      ],
+      [
+        {
+          "type": "sprite",
+          "image": "humphrey",
+          "x": "058",
+          "y": "31.2",
+          "size": "60.4",
+          "flipX": true
+        },
+        {
+          "type": "sprite",
+          "image": "net",
+          "x": 51.400000000000006,
+          "y": 51.20000000000001,
+          "size": "20.2",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "strawberry",
+          "x": "0004.600000000000001",
+          "y": "046.1",
+          "size": "25",
+          "flipX": false
+        }
+      ],
+      [
+        {
+          "type": "sprite",
+          "image": "net",
+          "x": "51.400000000000006",
+          "y": 46.1,
+          "size": "20.2",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "strawberry",
+          "x": 6.200000000000003,
+          "y": 33.4,
+          "size": "040",
+          "flipX": false
+        }
+      ]
+    ],
+    "dialogue": [
+      {
+        "speaker": "Humphrey",
+        "message": "Thank you again for your help! I’m going to find some plankton to eat!",
+        "type": "right"
+      },
+      null,
+      {
+        "speaker": "Strawberry",
+        "message": "I do wonder where this big net came from! Let’s take it back to shore so we can dispose of it properly, and we can try to figure out this mystery along the way.",
+        "type": "left"
+      }
+    ]
+  },
+};
+
+export default MEET_HUMPHREY;

--- a/marinerescue-frontend/src/data/stories/MeetJade.js
+++ b/marinerescue-frontend/src/data/stories/MeetJade.js
@@ -1,0 +1,937 @@
+const MEET_JADE = {
+  "Jade Story": {
+    "type": "comic",
+    "background": "beach-rocks-2",
+    "nextScene": "testScene2",
+    "baseFrame": [],
+    "frames": [
+      [
+        {
+          "type": "sprite",
+          "image": "strawberry",
+          "x": "01",
+          "y": "035",
+          "size": "035",
+          "flipX": false
+        }
+      ],
+      [
+        {
+          "type": "sprite",
+          "image": "strawberry",
+          "x": "01",
+          "y": "35",
+          "size": "035",
+          "flipX": false
+        }
+      ],
+      [
+        {
+          "type": "sprite",
+          "image": "strawberry-love",
+          "x": "01",
+          "y": "035",
+          "size": "040",
+          "flipX": false
+        }
+      ],
+      [
+        {
+          "type": "sprite",
+          "image": "strawberry-sad",
+          "x": "01",
+          "y": "35",
+          "size": "035",
+          "flipX": false
+        }
+      ],
+      [
+        {
+          "type": "sprite",
+          "image": "strawberry",
+          "x": "01",
+          "y": "035",
+          "size": "35",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "jade-happy",
+          "x": "055",
+          "y": "031",
+          "size": "022",
+          "flipX": true
+        }
+      ],
+      [
+        {
+          "type": "sprite",
+          "image": "strawberry",
+          "x": "1",
+          "y": "35",
+          "size": "35",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "jade-happy",
+          "x": "055",
+          "y": "31",
+          "size": "22",
+          "flipX": true
+        }
+      ],
+      [
+        {
+          "type": "sprite",
+          "image": "strawberry",
+          "x": "1",
+          "y": "35",
+          "size": "35",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "jade-happy",
+          "x": "055",
+          "y": "31",
+          "size": "22",
+          "flipX": true
+        },
+        {
+          "type": "sprite",
+          "image": "question",
+          "x": "055",
+          "y": "027",
+          "size": "02",
+          "flipX": false
+        }
+      ],
+      [
+        {
+          "type": "sprite",
+          "image": "strawberry",
+          "x": "1",
+          "y": "35",
+          "size": "35",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "jade-happy",
+          "x": "055",
+          "y": "31",
+          "size": "22",
+          "flipX": true
+        }
+      ],
+      [
+        {
+          "type": "sprite",
+          "image": "strawberry",
+          "x": "1",
+          "y": "35",
+          "size": "35",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "jade-happy",
+          "x": "055",
+          "y": "31",
+          "size": "22",
+          "flipX": true
+        },
+        {
+          "type": "sprite",
+          "image": "blue-bag",
+          "x": "051",
+          "y": "38",
+          "size": "010",
+          "flipX": false
+        }
+      ],
+      [
+        {
+          "type": "sprite",
+          "image": "strawberry-sad",
+          "x": "1",
+          "y": "35",
+          "size": "35",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "jade-happy",
+          "x": "055",
+          "y": "31",
+          "size": "22",
+          "flipX": true
+        },
+        {
+          "type": "sprite",
+          "image": "blue-bag",
+          "x": "51",
+          "y": "38",
+          "size": "10",
+          "flipX": false
+        }
+      ],
+      [
+        {
+          "type": "sprite",
+          "image": "strawberry-sad",
+          "x": "1",
+          "y": "35",
+          "size": "35",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "jade-happy",
+          "x": "055",
+          "y": "31",
+          "size": "22",
+          "flipX": true
+        },
+        {
+          "type": "sprite",
+          "image": "blue-bag",
+          "x": "51",
+          "y": "38",
+          "size": "010",
+          "flipX": false
+        }
+      ],
+      [
+        {
+          "type": "sprite",
+          "image": "strawberry-sad",
+          "x": "1",
+          "y": "35",
+          "size": "35",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "jade-happy",
+          "x": "055",
+          "y": "31",
+          "size": "22",
+          "flipX": true
+        },
+        {
+          "type": "sprite",
+          "image": "blue-bag",
+          "x": "51",
+          "y": "38",
+          "size": "010",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "exclaim",
+          "x": "056",
+          "y": "025",
+          "size": "01",
+          "flipX": false
+        }
+      ],
+      [
+        {
+          "type": "sprite",
+          "image": "strawberry-sad",
+          "x": "1",
+          "y": "35",
+          "size": "35",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "jade-sad",
+          "x": "055",
+          "y": "31",
+          "size": "22",
+          "flipX": true
+        },
+        {
+          "type": "sprite",
+          "image": "blue-bag",
+          "x": "030",
+          "y": "52",
+          "size": "10",
+          "flipX": false
+        }
+      ],
+      [
+        {
+          "type": "sprite",
+          "image": "strawberry",
+          "x": "1",
+          "y": "35",
+          "size": "35",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "jade-sad",
+          "x": "055",
+          "y": "31",
+          "size": "22",
+          "flipX": true
+        }
+      ],
+      [
+        {
+          "type": "sprite",
+          "image": "strawberry",
+          "x": "1",
+          "y": "35",
+          "size": "35",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "jade-happy",
+          "x": "055",
+          "y": "31",
+          "size": "22",
+          "flipX": true
+        }
+      ]
+    ],
+    "dialogue": [
+      {
+        "speaker": "Strawberry",
+        "message": "Let’s meet my friend Jade the Green Sea Turtle. She’s such a pretty color, I hope to be as good looking as her when I grow up!”",
+        "type": "right"
+      },
+      null,
+      {
+        "speaker": "Strawberry",
+        "message": "Thank you! ",
+        "type": "right"
+      },
+      {
+        "speaker": "Strawberry",
+        "message": "Oh. Okay. ",
+        "type": "right"
+      },
+      {
+        "speaker": "Jade",
+        "message": "Hello there! ",
+        "type": "left"
+      },
+      {
+        "speaker": "Strawberry",
+        "message": "Hi Jade! ",
+        "type": "right"
+      },
+      {
+        "speaker": "Jade",
+        "message": "Who’s that with you Strawberry? ",
+        "type": "left"
+      },
+      {
+        "speaker": "Strawberry",
+        "message": "This is my friend [NAME]! We’re here to check up on you!",
+        "type": "right"
+      },
+      {
+        "speaker": "Jade",
+        "message": "I’m absolutely great! I was able to eat my lunch right here!\nI caught it fresh, it’s a jellyfish! ",
+        "type": "left"
+      },
+      {
+        "speaker": "Strawberry",
+        "message": "Wait! Are you sure that it’s a jellyfish? It looks like a plastic bag instead.",
+        "type": "right"
+      },
+      {
+        "speaker": "Jade",
+        "message": ".....................",
+        "type": "left"
+      },
+      {
+        "speaker": "Jade",
+        "message": "You’re right! They look so similar, I’m glad you caught that. I would’ve gotten a horrible stomach ache.",
+        "type": "left"
+      },
+      {
+        "speaker": "Strawberry",
+        "message": "Yes, it is a problem. Hopefully, they’ll know that it’s important to properly throw away their trash! Let me take that bag away for you. I’ll put it in the trash bin shore.",
+        "type": "right"
+      },
+      {
+        "speaker": "Jade",
+        "message": "Now I need to get some new lunch. \nStrawberry, would you and [NAME] mind helping me catch some new food? I’ll share with you any leftovers I get!\n",
+        "type": "left"
+      },
+      null
+    ]
+  },
+  "Jade Journal": {
+    "type": "comic",
+    "background": "beige",
+    "nextScene": "testScene2",
+    "baseFrame": [],
+    "frames": [
+      [
+        {
+          "type": "sprite",
+          "image": "strawberry",
+          "x": "02",
+          "y": "35",
+          "size": "38",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "journal-closed",
+          "x": "040",
+          "y": "15",
+          "size": "60",
+          "flipX": false
+        }
+      ],
+      [
+        {
+          "type": "sprite",
+          "image": "strawberry",
+          "x": "02",
+          "y": "35",
+          "size": "38",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "journal-open",
+          "x": "040",
+          "y": "15",
+          "size": "60",
+          "flipX": false
+        }
+      ],
+      [
+        {
+          "type": "sprite",
+          "image": "strawberry",
+          "x": "02",
+          "y": "35",
+          "size": "38",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "journal-open",
+          "x": "040",
+          "y": "15",
+          "size": "060",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "journal-closed",
+          "x": 0,
+          "y": "02",
+          "size": "015",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "blue-circle",
+          "x": "051",
+          "y": "028",
+          "size": "012",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "jade-happy",
+          "x": "050",
+          "y": "029",
+          "size": "015",
+          "flipX": true
+        }
+      ],
+      [
+        {
+          "type": "sprite",
+          "image": "strawberry",
+          "x": "02",
+          "y": "35",
+          "size": "38",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "journal-open",
+          "x": "040",
+          "y": "15",
+          "size": "060",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "journal-closed",
+          "x": 0,
+          "y": "02",
+          "size": "015",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "blue-circle",
+          "x": "051",
+          "y": "028",
+          "size": "012",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "jade-happy",
+          "x": "050",
+          "y": "029",
+          "size": "015",
+          "flipX": true
+        }
+      ],
+      [
+        {
+          "type": "sprite",
+          "image": "strawberry",
+          "x": "02",
+          "y": "35",
+          "size": "38",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "journal-open",
+          "x": "040",
+          "y": "15",
+          "size": "060",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "journal-closed",
+          "x": 0,
+          "y": "02",
+          "size": "015",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "blue-circle",
+          "x": "051",
+          "y": "028",
+          "size": "012",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "jade-happy",
+          "x": "050",
+          "y": "029",
+          "size": "015",
+          "flipX": true
+        }
+      ],
+      [
+        {
+          "type": "sprite",
+          "image": "strawberry",
+          "x": "02",
+          "y": "35",
+          "size": "38",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "journal-open",
+          "x": "040",
+          "y": "15",
+          "size": "060",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "journal-closed",
+          "x": 0,
+          "y": "02",
+          "size": "015",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "blue-circle",
+          "x": "051",
+          "y": "028",
+          "size": "012",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "jade-happy",
+          "x": "050",
+          "y": "029",
+          "size": "015",
+          "flipX": true
+        }
+      ],
+      [
+        {
+          "type": "sprite",
+          "image": "strawberry",
+          "x": "02",
+          "y": "35",
+          "size": "38",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "journal-open",
+          "x": "040",
+          "y": "15",
+          "size": "060",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "journal-closed",
+          "x": 0,
+          "y": "02",
+          "size": "015",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "blue-circle",
+          "x": "051",
+          "y": "028",
+          "size": "012",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "jade-happy",
+          "x": "050",
+          "y": "029",
+          "size": "015",
+          "flipX": true
+        }
+      ],
+      [
+        {
+          "type": "sprite",
+          "image": "strawberry",
+          "x": "02",
+          "y": "35",
+          "size": "38",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "journal-open",
+          "x": "040",
+          "y": "15",
+          "size": "060",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "journal-closed",
+          "x": 0,
+          "y": "02",
+          "size": "015",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "blue-circle",
+          "x": "051",
+          "y": "028",
+          "size": "012",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "jade-happy",
+          "x": "050",
+          "y": "029",
+          "size": "015",
+          "flipX": true
+        }
+      ],
+      [
+        {
+          "type": "sprite",
+          "image": "strawberry",
+          "x": "02",
+          "y": "35",
+          "size": "38",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "journal-open",
+          "x": "040",
+          "y": "15",
+          "size": "060",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "journal-closed",
+          "x": 0,
+          "y": "02",
+          "size": "015",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "blue-circle",
+          "x": "051",
+          "y": "028",
+          "size": "012",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "jade-happy",
+          "x": "050",
+          "y": "029",
+          "size": "015",
+          "flipX": true
+        }
+      ],
+      [
+        {
+          "type": "sprite",
+          "image": "strawberry",
+          "x": "02",
+          "y": "35",
+          "size": "38",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "journal-open",
+          "x": "040",
+          "y": "15",
+          "size": "60",
+          "flipX": false
+        }
+      ],
+      [
+        {
+          "type": "sprite",
+          "image": "strawberry",
+          "x": "02",
+          "y": "35",
+          "size": "38",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "journal-open",
+          "x": "040",
+          "y": "15",
+          "size": "60",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "blue-bag",
+          "x": "048",
+          "y": "030",
+          "size": "018",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "journal-closed",
+          "x": 0,
+          "y": "02",
+          "size": "15",
+          "flipX": false
+        }
+      ],
+      [
+        {
+          "type": "sprite",
+          "image": "strawberry",
+          "x": "02",
+          "y": "35",
+          "size": "38",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "journal-open",
+          "x": "040",
+          "y": "15",
+          "size": "60",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "blue-bag",
+          "x": "048",
+          "y": "030",
+          "size": "018",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "journal-closed",
+          "x": 0,
+          "y": "02",
+          "size": "15",
+          "flipX": false
+        }
+      ],
+      [
+        {
+          "type": "sprite",
+          "image": "strawberry",
+          "x": "02",
+          "y": "35",
+          "size": "38",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "journal-open",
+          "x": "040",
+          "y": "15",
+          "size": "60",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "blue-bag",
+          "x": "048",
+          "y": "030",
+          "size": "018",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "journal-closed",
+          "x": 0,
+          "y": "02",
+          "size": "15",
+          "flipX": false
+        }
+      ],
+      [
+        {
+          "type": "sprite",
+          "image": "strawberry",
+          "x": "02",
+          "y": "35",
+          "size": "38",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "journal-open",
+          "x": "040",
+          "y": "15",
+          "size": "60",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "blue-bag",
+          "x": "048",
+          "y": "030",
+          "size": "018",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "journal-closed",
+          "x": 0,
+          "y": "02",
+          "size": "15",
+          "flipX": false
+        }
+      ],
+      [
+        {
+          "type": "sprite",
+          "image": "strawberry",
+          "x": "02",
+          "y": "35",
+          "size": "38",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "journal-open",
+          "x": "040",
+          "y": "15",
+          "size": "60",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "blue-bag",
+          "x": "048",
+          "y": "030",
+          "size": "018",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "journal-closed",
+          "x": 0,
+          "y": "02",
+          "size": "15",
+          "flipX": false
+        }
+      ]
+    ]
+  },
+  "Squawky Story": {
+    "type": "comic",
+    "background": "beach-big",
+    "nextScene": "testScene2",
+    "baseFrame": [],
+    "frames": [
+      [
+        {
+          "type": "sprite",
+          "image": "strawberry",
+          "x": "01",
+          "y": "30",
+          "size": "035",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "sqwackyv2-BELLY",
+          "x": "080",
+          "y": "018",
+          "size": "14",
+          "flipX": true
+        }
+      ],
+      [],
+      []
+    ],
+    "dialogue": [
+      {
+        "speaker": "Strawberry",
+        "message": "Do you see my friend Squawky over there in the water?\nSquawky is an albatross! Let’s go say hi.",
+        "type": "right"
+      },
+      null
+    ]
+  },
+}
+
+export default MEET_JADE;

--- a/marinerescue-frontend/src/data/stories/MeetStrawberry.js
+++ b/marinerescue-frontend/src/data/stories/MeetStrawberry.js
@@ -1,0 +1,179 @@
+const MEET_STRAWBERRY = {
+  "MeetStrawberry": {
+    "type": "comic",
+    "background": "beach-big",
+    "nextScene": "meetstrawberry-towater",
+    "baseFrame": [
+      {
+        "type": "sprite",
+        "image": "strawberry",
+        "x": 25.799999999999997,
+        "y": 33.7,
+        "size": "40",
+        "flipX": false
+      }
+    ],
+    "frames": [
+      [],
+      []
+    ],
+    "dialogue": [
+      {
+        "speaker": "Strawberry",
+        "message": "Hi there! My name is Strawberry. I’m a Harbor Seal and I live in the Puget Sound.",
+        "type": "left"
+      },
+      {
+        "speaker": "Strawberry",
+        "message": "Welcome to my favorite beach! It’s the Penn Cove Beach on Whidbey Island.",
+        "type": "left"
+      }
+    ]
+  },
+  "MeetStrawberry-towater": {
+    "type": "comic",
+    "background": "beach-small",
+    "nextScene": "meetstrawberry-inwater",
+    "baseFrame": [],
+    "frames": [
+      [
+        {
+          "type": "sprite",
+          "image": "strawberry",
+          "x": "25.7",
+          "y": "037",
+          "size": "040",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "lighter",
+          "x": 92.5,
+          "y": 39.3,
+          "size": "03",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "fishingline",
+          "x": 84.8,
+          "y": 43.1,
+          "size": "015",
+          "flipX": false
+        },
+        {
+          "type": "sprite",
+          "image": "blue-bag",
+          "x": 93.89999999999999,
+          "y": 38.5,
+          "size": "010",
+          "flipX": false
+        }
+      ]
+    ],
+    "dialogue": [
+      {
+        "speaker": "Strawberry",
+        "message": "I come here all the time to bask in the sun and meet up with my animal friends!",
+        "type": "left"
+      }
+    ]
+  },
+  "MeetStrawberry-inwater": {
+    "type": "comic",
+    "background": "sea-mountains",
+    "nextScene": "testScene2",
+    "baseFrame": [
+      {
+        "type": "sprite",
+        "image": "blue-bag",
+        "x": 72,
+        "y": 40.1,
+        "size": "20",
+        "flipX": false
+      },
+      {
+        "type": "sprite",
+        "image": "lighter",
+        "x": 68.1,
+        "y": 37.3,
+        "size": "06",
+        "flipX": false
+      },
+      {
+        "type": "sprite",
+        "image": "fishingline",
+        "x": 61.79999999999999,
+        "y": 46.9,
+        "size": "30",
+        "flipX": false
+      }
+    ],
+    "frames": [
+      [
+        {
+          "type": "sprite",
+          "image": "strawberry-surprised",
+          "x": 12.099999999999998,
+          "y": "32.4",
+          "size": "43",
+          "flipX": false
+        }
+      ],
+      [
+        {
+          "type": "sprite",
+          "image": "strawberry",
+          "x": 12.2,
+          "y": 35.00000000000001,
+          "size": "040",
+          "flipX": false
+        }
+      ],
+      [
+        {
+          "type": "sprite",
+          "image": "strawberry-sad",
+          "x": "11.800000000000004",
+          "y": "034.2",
+          "size": "40",
+          "flipX": false
+        }
+      ],
+      [
+        {
+          "type": "sprite",
+          "image": "strawberry",
+          "x": "11.800000000000004",
+          "y": "034.2",
+          "size": "40.3",
+          "flipX": false
+        }
+      ]
+    ],
+    "dialogue": [
+      {
+        "speaker": "Strawberry",
+        "message": "Oh no! Is that more marine debris?",
+        "type": "left"
+      },
+      {
+        "speaker": "Strawberry",
+        "message": "Recently, a lot of humans have been leaving their trash on the beach. When it gets swept into the water, scientists call it marine debris.",
+        "type": "left"
+      },
+      {
+        "speaker": "Strawberry",
+        "message": "Marine debris can harm me and my friends in different ways depending on the characteristics. Seeing all this debris makes me worried for my friends.",
+        "type": "left"
+      },
+      {
+        "speaker": "Strawberry",
+        "message": "Let’s go check on them together!",
+        "type": "left"
+      }
+    ]
+  },
+};
+
+export default MEET_STRAWBERRY;

--- a/marinerescue-frontend/src/data/stories/MeetStrawberry.js
+++ b/marinerescue-frontend/src/data/stories/MeetStrawberry.js
@@ -82,7 +82,7 @@ const MEET_STRAWBERRY = {
   "MeetStrawberry-inwater": {
     "type": "comic",
     "background": "sea-mountains",
-    "nextScene": "testScene2",
+    "nextScene": "GOTO /play?next=squawky",
     "baseFrame": [
       {
         "type": "sprite",

--- a/marinerescue-frontend/src/pages/EditorPage.js
+++ b/marinerescue-frontend/src/pages/EditorPage.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import minigames from '../components/minigames';
-import storytellerData from '../storytellerData';
+import STORYTELLER_DATA from '../data/StorytellerData';
 import Dropdown from '../components/Dropdown';
 import ComicView from '../components/ComicView';
 import './EditorPage.scss';
@@ -76,7 +76,7 @@ class EditorPage extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            storytellerData: storytellerData,
+            storytellerData: STORYTELLER_DATA,
             currentSceneName: 'testScene',
             currentFrame: 0,
             targetSpriteIdx: -1,

--- a/marinerescue-frontend/src/pages/GameLandingPage.js
+++ b/marinerescue-frontend/src/pages/GameLandingPage.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import NavBar from '../components/NavBar';
 import Footer from '../components/Footer';
-import { Link } from "react-router-dom";
+import { Link, withRouter } from "react-router-dom";
 
 import './GameLandingPage.scss';
 
@@ -9,12 +9,14 @@ import MODULES from '../data/Modules';
 
 class GameLandingPage extends React.Component {
   renderModules() {
+    const next = (new URLSearchParams(this.props.location.search)).get('next');
     return (
       <>
         {
           MODULES.map((module, idx) => {
             const isAlt = idx % 2 !== 0;
             const isLocked = idx > 3 || idx === 1;
+            const isNext = module.tag === next;
 
             let classes = 'game-module-section';
             if (isAlt) {
@@ -23,9 +25,13 @@ class GameLandingPage extends React.Component {
             if (isLocked) {
               classes += ' game-module-section-locked';
             }
+            if (isNext) {
+              classes += ' game-module-section-next';
+            }
 
             return (
               <div className={classes} key={idx}>
+                <a id={module.tag} class="anchor" />
                 <div className="module-deco">
                   {
                     module.icon
@@ -51,6 +57,13 @@ class GameLandingPage extends React.Component {
     );
   }
 
+  componentDidMount() {
+    const next = (new URLSearchParams(this.props.location.search)).get('next');
+    if (!!next) {
+      window.location.hash = next;
+    }
+  }
+
   render() {
     return (
       <div id="game-landing-page">
@@ -69,4 +82,4 @@ class GameLandingPage extends React.Component {
   }
 }
 
-export default GameLandingPage;
+export default withRouter(GameLandingPage);

--- a/marinerescue-frontend/src/pages/GameLandingPage.js
+++ b/marinerescue-frontend/src/pages/GameLandingPage.js
@@ -14,7 +14,7 @@ class GameLandingPage extends React.Component {
         {
           MODULES.map((module, idx) => {
             const isAlt = idx % 2 !== 0;
-            const isLocked = idx > 2;
+            const isLocked = idx > 3 || idx === 1;
 
             let classes = 'game-module-section';
             if (isAlt) {

--- a/marinerescue-frontend/src/pages/GameLandingPage.js
+++ b/marinerescue-frontend/src/pages/GameLandingPage.js
@@ -8,65 +8,65 @@ import './GameLandingPage.scss';
 import MODULES from '../data/Modules';
 
 class GameLandingPage extends React.Component {
-    renderModules() {
-        return (
-            <>
-                {
-                    MODULES.map((module, idx) => {
-                        const isAlt = idx % 2 !== 0;
-                        const isLocked = idx > 2;
+  renderModules() {
+    return (
+      <>
+        {
+          MODULES.map((module, idx) => {
+            const isAlt = idx % 2 !== 0;
+            const isLocked = idx > 2;
 
-                        let classes = 'game-module-section';
-                        if (isAlt) {
-                            classes += ' game-module-section-alt';
-                        }
-                        if (isLocked) {
-                            classes += ' game-module-section-locked';
-                        }
+            let classes = 'game-module-section';
+            if (isAlt) {
+              classes += ' game-module-section-alt';
+            }
+            if (isLocked) {
+              classes += ' game-module-section-locked';
+            }
 
-                        return (
-                            <div className={classes} key={idx}>
-                                <div className="module-deco">
-                                    {
-                                        module.icon
-                                            && <img src={module.icon} alt={`Icon for ${module.title} module`} />
-                                    }
-                                </div>
-                                <div className="module-box-container">
-                                    <div className="module-box">
-                                        <h2>{module.title}</h2>
-                                        <p>{module.subtitle}</p>
-                                        {
-                                            isLocked
-                                                ? <button className="std-btn disabled" to={module.target} disabled>Locked</button>
-                                                : <Link className="std-btn sunshine" to={module.target}>Play Now</Link>
-                                        }                                   
-                                    </div>
-                                </div>
-                            </div>
-                        );
-                    })
-                }
-            </>
-        );
-    }
-
-    render() {
-        return (
-            <div id="game-landing-page">
-                <NavBar></NavBar>
-                <main id="game-map-container">
-                    <div id="game-map">
-                        {this.renderModules()}
-                    </div>
-                </main>
-                
-                <div className="section">
-                    <Footer></Footer>
+            return (
+              <div className={classes} key={idx}>
+                <div className="module-deco">
+                  {
+                    module.icon
+                    && <img src={module.icon} alt={`Icon for ${module.title} module`} />
+                  }
                 </div>
-            </div>
-        );
-    }
+                <div className="module-box-container">
+                  <div className="module-box">
+                    <h2>{module.title}</h2>
+                    <p>{module.subtitle}</p>
+                    {
+                      isLocked
+                        ? <button className="std-btn disabled" to={module.target} disabled>Locked</button>
+                        : <Link className="std-btn sunshine" to={module.target}>Play Now</Link>
+                    }
+                  </div>
+                </div>
+              </div>
+            );
+          })
+        }
+      </>
+    );
+  }
+
+  render() {
+    return (
+      <div id="game-landing-page">
+        <NavBar></NavBar>
+        <main id="game-map-container">
+          <div id="game-map">
+            {this.renderModules()}
+          </div>
+        </main>
+
+        <div className="section">
+          <Footer></Footer>
+        </div>
+      </div>
+    );
+  }
 }
 
 export default GameLandingPage;

--- a/marinerescue-frontend/src/pages/GameLandingPage.scss
+++ b/marinerescue-frontend/src/pages/GameLandingPage.scss
@@ -22,6 +22,10 @@
                 align-items: center;
                 margin: 64px 0;
 
+                a.anchor {
+                    align-self: flex-start;
+                }
+
                 &.game-module-section-alt {
                     flex-direction: row-reverse;
                 }
@@ -33,6 +37,20 @@
                         .std-btn {
                             background-color: $dark;
                             cursor: not-allowed;
+                        }
+                    }
+                }
+
+                &.game-module-section-next {
+                    .module-box {
+                        animation-name: grow-shrink;
+                        animation-duration: 2000ms;
+                        animation-direction: alternate;
+                        animation-iteration-count: infinite;
+                        animation-timing-function: ease-in-out;
+
+                        &:hover {
+                            animation-play-state: paused;
                         }
                     }
                 }
@@ -105,5 +123,14 @@
                 }
             }
         }
+    }
+}
+
+@keyframes grow-shrink {
+    from {
+        transform: scale(0.9);
+    }
+    to {
+        transform: scale(1.1);
     }
 }

--- a/marinerescue-frontend/src/pages/GameLandingPage.scss
+++ b/marinerescue-frontend/src/pages/GameLandingPage.scss
@@ -90,6 +90,7 @@
                     display: flex;
                     align-items: center;
                     justify-content: center;
+                    max-width: 100vw;
 
                     .module-box {
                         background-color: $blue;

--- a/marinerescue-frontend/src/pages/JournalPage.js
+++ b/marinerescue-frontend/src/pages/JournalPage.js
@@ -3,7 +3,7 @@ import {
     Journal,
     JOURNAL_TOC_VIEW,
 } from '../components/Journal';
-import journalData from '../journalData';
+import JOURNAL_DATA from '../data/JournalData';
 import './JournalPage.scss';
 
 class JournalPage extends React.Component {
@@ -35,7 +35,7 @@ class JournalPage extends React.Component {
                 </button>
                 <div id="journal-page-content">
                     <Journal
-                        data={journalData}
+                        data={JOURNAL_DATA}
                         view={this.state.view}
                         page={this.state.page}
                         onNavigate={this.onNavigate.bind(this)} />

--- a/marinerescue-frontend/src/pages/StorytellerPage.js
+++ b/marinerescue-frontend/src/pages/StorytellerPage.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import Storyteller from '../components/Storyteller';
+
+const START_SCENE_MAP = {
+  'strawberry': 'MeetStrawberry',
+  'humphrey': 'MeetHumphrey',
+  'jade': 'Jade Story',
+}
+
+class StorytellerPage extends React.Component {
+  render() {
+    const startScene = START_SCENE_MAP[this.props.startSceneLabel];
+    return <Storyteller startScene={startScene} />
+  }
+}
+
+export default StorytellerPage;


### PR DESCRIPTION
This PR combines all the received stories, adds links to them from the game landing page, and enables user-friendly transitions between stories.

**See what a user will see when they're finished with the Humphrey story, and are prompted to begin Jade's story: [http://applejack-preview-landing.surge.sh/play?next=jade](http://applejack-preview-landing.surge.sh/play?next=jade)**

# Changes

* Add Strawberry, Humphrey, and Jade stories
* Add `StorytellerPage` component as an intermediary between the router and the `Storyteller`
* Storyteller `nextScene` can now indicate webpages as the next scene (i.e. `"nextScene": "GOTO /play?next=squawky"`)
* `GameLandingPage` adds a user-friendly animation to help users transition between stories
* Fix minor bugs with Storyteller

# Known issues

* Footer is broke on game landing page. This is out of scope for this PR since we are rebuilding the footer anyway.
* Stories are missing minigames. This is out of scope for this PR.